### PR TITLE
Added an array for unary multiboot tags to be able to fetch them in constant-time

### DIFF
--- a/kernel/include/3rd/multiboot2.h
+++ b/kernel/include/3rd/multiboot2.h
@@ -42,6 +42,8 @@
 /*  Flags set in the ’flags’ member of the multiboot header. */
 
 #define MULTIBOOT_TAG_ALIGN 8
+#define MULTIBOOT_TAG_TOTAL 22
+
 #define MULTIBOOT_TAG_TYPE_END 0
 #define MULTIBOOT_TAG_TYPE_CMDLINE 1
 #define MULTIBOOT_TAG_TYPE_BOOT_LOADER_NAME 2

--- a/kernel/include/kreflock.h
+++ b/kernel/include/kreflock.h
@@ -34,11 +34,11 @@ typedef struct {
 } reflock_t;
 
 #define NEW_REFLOCK(_on_lock, _on_unlock, _strict, _allow_force)               \
-	{ _on_lock,                                                                \
-	  _on_unlock,                                                              \
-	  _strict,                                                                 \
-	  _allow_force,                                                            \
-	  { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } }
+	{                                                                          \
+		_on_lock, _on_unlock, _strict, _allow_force, {                         \
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0                                 \
+		}                                                                      \
+	}
 
 void reflock_make(reflock_t *lock);
 bool reflock_validate_magic(reflock_t *lock);

--- a/kernel/include/multiboot2.h
+++ b/kernel/include/multiboot2.h
@@ -1,0 +1,23 @@
+#ifndef __K_MULTIBOOT2
+#define __K_MULTIBOOT2
+
+#include "3rd/multiboot2.h"
+#include <stdint.h>
+
+// STUB!
+typedef int list_head;
+
+// make it tag-like to fit better with get_multiboot_tag
+struct multiboot_module_list_tag {
+	multiboot_uint16_t type;  // will be MULTIBOOT_TAG_MODULE
+	multiboot_uint16_t flags; // will be 0
+	multiboot_uint32_t size; // will be sizeof(struct multiboot_module_list_tag)
+
+	struct multiboot_tag_module *module;
+	list_head list;
+};
+
+struct multiboot_tag *get_multiboot_tag(uint8_t tag_id);
+int multiboot2_init(uint64_t *addr, uint32_t magic);
+
+#endif

--- a/kernel/multiboot2.c
+++ b/kernel/multiboot2.c
@@ -9,7 +9,7 @@ static struct multiboot_tag *unary_tags[MULTIBOOT_TAG_TOTAL];
 
 #define CHECK_FLAG(flags, bit) ((flags) & (1 << (bit)))
 
-struct multiboot_tag_list *get_multiboot_tag(uint8_t tag_id) {
+struct multiboot_tag *get_multiboot_tag(uint8_t tag_id) {
 	if (tag_id < 0 || tag_id >= MULTIBOOT_TAG_TOTAL) {
 		return NULL;
 	}
@@ -42,7 +42,7 @@ int multiboot2_init(uint64_t *addr, uint32_t magic) {
 
 	// set all tags to NULL
 	memset(unary_tags, 0x00,
-	       sizeof(struct multiboot_tag_list *) * MULTIBOOT_TAG_TOTAL);
+	       sizeof(struct multiboot_tag *) * MULTIBOOT_TAG_TOTAL);
 
 	tag = (struct multiboot_tag *)(mbi_addr + sizeof(uint64_t));
 

--- a/kernel/multiboot2.c
+++ b/kernel/multiboot2.c
@@ -1,9 +1,21 @@
+#include "multiboot2.h"
+#include "3rd/multiboot2.h"
 #include "khal.h"
 #include "kstdlib.h"
-#include <3rd/multiboot2.h>
+#include "kstring.h"
 #include <stdint.h>
 
+static struct multiboot_tag *unary_tags[MULTIBOOT_TAG_TOTAL];
+
 #define CHECK_FLAG(flags, bit) ((flags) & (1 << (bit)))
+
+struct multiboot_tag_list *get_multiboot_tag(uint8_t tag_id) {
+	if (tag_id < 0 || tag_id >= MULTIBOOT_TAG_TOTAL) {
+		return NULL;
+	}
+
+	return unary_tags[tag_id];
+}
 
 void handle_cmdline_tag(struct multiboot_tag *tag);
 void handle_module_tag(struct multiboot_tag *tag);
@@ -28,6 +40,10 @@ int multiboot2_init(uint64_t *addr, uint32_t magic) {
 	uint64_t size = *addr;
 	serial_printf("Announced mbi size 0x%x\n", size);
 
+	// set all tags to NULL
+	memset(unary_tags, 0x00,
+	       sizeof(struct multiboot_tag_list *) * MULTIBOOT_TAG_TOTAL);
+
 	tag = (struct multiboot_tag *)(mbi_addr + sizeof(uint64_t));
 
 	while (tag->type != MULTIBOOT_TAG_TYPE_END) {
@@ -51,6 +67,10 @@ int multiboot2_init(uint64_t *addr, uint32_t magic) {
 				serial_printf("Tag at 0x%x | %d\n", (uintptr_t)tag, tag->type);
 				break;
 		}
+
+		// there can be more than one of those
+		// module tags will be handled separately after heap init
+		if (tag->type != MULTIBOOT_TAG_TYPE_MODULE) unary_tags[tag->type] = tag;
 
 		// Move to the next tag
 		tag = (struct multiboot_tag *)((uintptr_t)tag) + ((tag->size + 7) & ~7);

--- a/kernel/multiboot2.c
+++ b/kernel/multiboot2.c
@@ -3,6 +3,7 @@
 #include "khal.h"
 #include "kstdlib.h"
 #include "kstring.h"
+#include "sys/panic.h"
 #include <stdint.h>
 
 static struct multiboot_tag *unary_tags[MULTIBOOT_TAG_TOTAL];
@@ -67,6 +68,10 @@ int multiboot2_init(uint64_t *addr, uint32_t magic) {
 				serial_printf("Tag at 0x%x | %d\n", (uintptr_t)tag, tag->type);
 				break;
 		}
+
+		// In case I'm just stupid
+		if (unary_tags[tag->type])
+			PANIC("Duplicate multiboot tag during initialization"); 
 
 		// there can be more than one of those
 		// module tags will be handled separately after heap init

--- a/kernel/multiboot2.c
+++ b/kernel/multiboot2.c
@@ -71,7 +71,7 @@ int multiboot2_init(uint64_t *addr, uint32_t magic) {
 
 		// In case I'm just stupid
 		if (unary_tags[tag->type])
-			PANIC("Duplicate multiboot tag during initialization"); 
+			PANIC("Duplicate multiboot tag during initialization");
 
 		// there can be more than one of those
 		// module tags will be handled separately after heap init


### PR DESCRIPTION
Usage example:
```c
struct multiboot_tag_mmap *multiboot_mmap =
	    (struct multiboot_tag_mmap *)get_multiboot_tag(MULTIBOOT_TAG_TYPE_MMAP);
```
The array is initialized in `kernel_mmap_init()`, with an exception to `MULTIBOOT_TAG_TYPE_MODULE`, since there may be more than one of them and a list-like structure should be made for them.